### PR TITLE
filter out non-ohm bonds on useAllAuctionInfoWithParticipation

### DIFF
--- a/src/hooks/useAllAuctionInfos.ts
+++ b/src/hooks/useAllAuctionInfos.ts
@@ -79,8 +79,11 @@ export const useAllAuctionInfoWithParticipation = (account: string): Maybe<Aucti
         if (!additionalServiceApi) {
           throw new Error('missing dependencies in useAllAuctionInfoWithParticipation callback')
         }
-        const auctionInfo = await additionalServiceApi.getAllAuctionDetailsWithUserParticipation(
+        const auctionInfoAll = await additionalServiceApi.getAllAuctionDetailsWithUserParticipation(
           account,
+        )
+        const auctionInfo = auctionInfoAll.filter(
+          (auction) => auction.addressBiddingToken === '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5',
         )
         if (cancelled) return
         setAllAuctions(auctionInfo)


### PR DESCRIPTION
https://github.com/OlympusDAO/gnosis-ido-ux/pull/2 did not realize there was a separate hook for connected wallets, this pr adds the same filter as the previous pr in the other hook